### PR TITLE
Fix the error message for unresolved hostname

### DIFF
--- a/portscanner.py
+++ b/portscanner.py
@@ -41,7 +41,7 @@ except KeyboardInterrupt:
     print("\nbye...")
     sys.exit()
 except socket.gaierror:
-    print("Host name is could be Resolved")
+    print("Host name could not be Resolved")
     sys.exit
 except socket.error:
     print("Could not Connect to Server")


### PR DESCRIPTION
## Description
The unresolved hostname error captured by ```except socket.gaierror:``` wasn't giving users the relevant information. Fixed that for you so the users know they have issues with hostname not being resolved when trying to scan the ports of their target host. 